### PR TITLE
Launch the "Go to frame" window using CTRL + G regardless of where the focus is inside the video preview window

### DIFF
--- a/core/gui/NumberChooser.Designer.cs
+++ b/core/gui/NumberChooser.Designer.cs
@@ -120,6 +120,7 @@ namespace MeGUI.core.gui
             // NumberChooser
             // 
             this.AcceptButton = this.button2;
+            this.CancelButton = button1;
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(368, 149);

--- a/core/gui/NumberChooser.cs
+++ b/core/gui/NumberChooser.cs
@@ -72,5 +72,15 @@ namespace MeGUI.core.gui
             }
         }
 
+        protected override bool ProcessDialogKey(Keys keyData)
+        {
+            if (keyData == Keys.Escape)
+            {
+                DialogResult = DialogResult.Cancel;
+                Close();
+                return true;
+            }
+            return base.ProcessDialogKey(keyData);
+        }
     }
 }

--- a/core/gui/VideoPlayer.Designer.cs
+++ b/core/gui/VideoPlayer.Designer.cs
@@ -96,7 +96,6 @@ namespace MeGUI
             goToFrameButton.TabIndex = 13;
             goToFrameButton.Text = "Go to frame";
             goToFrameButton.Click += new System.EventHandler(this.goToFrameButton_Click);
-            goToFrameButton.KeyDown += new System.Windows.Forms.KeyEventHandler(this.goToFrameButton_KeyDown);
             // 
             // contextMenu1
             // 

--- a/core/gui/VideoPlayer.cs
+++ b/core/gui/VideoPlayer.cs
@@ -962,18 +962,18 @@ namespace MeGUI
 
         protected override bool ProcessDialogKey(Keys keyData)
         {
-            if (Form.ModifierKeys == Keys.None && keyData == Keys.Escape)
+            switch (keyData)
             {
-                this.Close();
-                return true;
-            }
-            return base.ProcessDialogKey(keyData);
-        }
+                case Keys.Escape:
+                    Close();
+                    return true;
 
-        private void goToFrameButton_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.KeyCode == Keys.G && Control.ModifierKeys == Keys.Control)
-                goToFrameButton_Click(null, null);
+                case Keys.Control | Keys.G:
+                    goToFrameButton_Click(null, EventArgs.Empty);
+                    return true;
+            }
+
+            return base.ProcessDialogKey(keyData);
         }
 
         private void videoPreview_PositionChanged(object sender, EventArgs e)


### PR DESCRIPTION
Also close this window using ESC
This now mimics the behavior of the keyboard shortcuts in VirtualDub and MPC-HC

Related discussion: https://github.com/Kurtnoise-zeus/megui/issues/49